### PR TITLE
Improve session management API

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,23 +19,25 @@
   </style>
 </head>
 
-<body>
-  <co-editor username="Pekka" id="one" master></co-editor>
+<body onload="init()">
+  <co-editor username="Pekka" id="one"></co-editor>
   <co-editor username="Paavo" id="two"></co-editor>
   <button id="join">Join session</button>
 
   <script>
-    const first = document.querySelector('#one');
-    const second = document.querySelector('#two');
+    function init() {
+      const first = document.querySelector('#one');
+      const second = document.querySelector('#two');
 
-    const delay = 5000;
-    first.addEventListener('update', e => setTimeout(() => second.receive(e.detail), delay));
-    second.addEventListener('update', e => setTimeout(() => first.receive(e.detail), delay));
+      first.initSession();
 
-    document.querySelector("#join").addEventListener('click', e => {
-      second.receive(first.generateJoinMessage());
-    });
-
+      const delay = 5000;
+      first.addEventListener('update', e => setTimeout(() => second.receive(e.detail), delay));
+      second.addEventListener('update', e => setTimeout(() => first.receive(e.detail), delay));
+      document.querySelector("#join").addEventListener('click', e => {
+        second.joinSession();
+      });
+    }
   </script>
 </body>
 

--- a/src/co-editor.js
+++ b/src/co-editor.js
@@ -37,6 +37,9 @@ class CoEditor extends SessionHandler {
     }
     switch (operation.type) {
 
+      case 'request-join':
+        this._joinRequested(operation);
+        break;
       case 'join':
         this._joinSession(operation);
         break;

--- a/src/generate-uuid.js
+++ b/src/generate-uuid.js
@@ -1,0 +1,12 @@
+// https://stackoverflow.com/a/8809472
+export default function generateUUID() { // Public Domain/MIT
+    var d = new Date().getTime();
+    if (typeof performance !== 'undefined' && typeof performance.now === 'function'){
+        d += performance.now(); //use high-precision timer if available
+    }
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+        var r = (d + Math.random() * 16) % 16 | 0;
+        d = Math.floor(d / 16);
+        return (c === 'x' ? r : (r & 0x3 | 0x8)).toString(16);
+    });
+}

--- a/src/session-handler.js
+++ b/src/session-handler.js
@@ -1,4 +1,5 @@
 import OTHandler from "./ot-handler.js";
+import generateUUID from './generate-uuid.js';
 
 export default class SessionHandler extends OTHandler {
 
@@ -7,66 +8,52 @@ export default class SessionHandler extends OTHandler {
     this._disable();
   }
 
-  static get observedAttributes() { return ['master']; }
-
-  attributeChangedCallback(name, oldValue, newValue) {
-    if (this.master) {
-      this._nextId = 0;
-      this._id = this._generateId();
-      this._stateVector[this._id] = 0;
-      this._enable();
-    } else {
-      this._disable();
-    }
-  }
-
-  get master() {
-    return this.hasAttribute('master');
-  }
-
-  set master(value) {
-    if (value) {
-      this.setAttribute('master', value);
-    } else {
-      this.removeAttribute('master');
-    }
-  }
-
   _isActive() {
-    return this.master || this._joined;
+    return this._master || this._joined;
   }
 
   _generateId() {
     return this._nextId++;
   }
 
-  /**
-   * Returns a message that contains information for
-   * another client to join this client's session.
-   */
-  generateJoinMessage() {
-    if (!this.master) {
-      throw new Error('Only a master editor can generate ' +
-        'a message for others to join its session. ' +
-        'Set the "master" attribute on the editor first.');
-    }
+  initSession() {
+    this._master = true;
+    this._nextId = 0;
+    this._id = this._generateId();
+    this._stateVector[this._id] = 0;
+    this._enable();
+  }
 
+  joinSession() {
+    this.__tmpId = generateUUID();
+    this.__send({
+      type: 'request-join',
+      tmpId: this.__tmpId
+    });
+    console.log(this.__tmpId);
+  }
+
+  _joinRequested(op) {
+    if (!this._master) {
+      return;
+    }
     const id = this._generateId();
     this._stateVector[id] = 0;
 
-    return JSON.stringify({
+    const joinMessage = {
       type: 'join',
+      tmpId: op.tmpId,
       id: id,
       stateVector: Object.assign({}, this._stateVector),
       text: this.value
       // TODO: include caret positions?
-    });
+    };
+    this.__send(joinMessage);
   }
 
   _joinSession(message) {
-    if (this.master) {
-      throw new Error('A master editor received a ' +
-        'message to join another session. This is not allowed.');
+    if (this._isActive() || message.tmpId !== this.__tmpId) {
+      return;
     }
     this._enable();
 

--- a/test/co-editor.test.js
+++ b/test/co-editor.test.js
@@ -15,13 +15,14 @@ describe('<co-editor>', () => {
   beforeEach(async () => {
     parent = await fixture(html`
       <div>
-        <co-editor id="one" master></co-editor>
+        <co-editor id="one"></co-editor>
         <co-editor id="two"></co-editor>
       </div>
     `);
     first = parent.querySelector("#one");
     second = parent.querySelector("#two");
     allClients = [first, second];
+    first.initSession();
   });
 
   const setInitialText = text =>
@@ -62,12 +63,14 @@ describe('<co-editor>', () => {
   describe('join session', () => {
     it('should set typed initial text', () => {
       insertText(first, 0, 'foo');
-      second.receive(first.generateJoinMessage());
+      first.addEventListener('update', e => second.receive(e.detail));
+      second.joinSession();
+      debugger;
       expectText(second, 'foo');
     });
     it('should set initial text set as property', () => {
       first.value = 'foo';
-      second.receive(first.generateJoinMessage());
+      second.joinSession();
       expectText(second, 'foo');
     });
     it('should execute queued ops', () => {
@@ -108,7 +111,7 @@ describe('<co-editor>', () => {
 
     beforeEach(() => {
       delay = undefined;
-      second.receive(first.generateJoinMessage());
+      second.joinSession();
     });
 
     describe('two clients', () => {


### PR DESCRIPTION
Changes based on evaluation.

Instead of master attribute, use initSession function.

Instead of calling generateJoinMessage and routing it manually, just
call joinSession, and the joining client will communicate with the
session initializer automatically.